### PR TITLE
4 Continuous Questions flow to the participant

### DIFF
--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -10,7 +10,7 @@ two:
   participant: one
   campaign: malaria
   question_text: "Have you ever suffered from Malaria?"
-  option: "Yes"
+  question_reply: "Yes"
 
 three:
   participant: three

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -9,5 +9,9 @@ question_one:
   campaign: malaria
 
 question_two:
-  title: do you know about proteins
+  title: do you know about proteins?
+  campaign: malaria
+
+question_three:
+  title: how can one prevent malaria?
   campaign: malaria

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -9,13 +9,13 @@ class AnswerTest < ActiveSupport::TestCase
     assert @answer.valid?
   end
 
-  test 'invalid without an option_id' do
-    @answer.option_id = nil
+  test 'invalid without an question_reply' do
+    @answer.question_reply = nil
     assert_not @answer.valid?
   end
 
-  test 'invalid without a question_id' do
-    @answer.question_id = nil
+  test 'invalid without a question_text' do
+    @answer.question_text = nil
     assert_not @answer.valid?
   end
 

--- a/test/models/option_test.rb
+++ b/test/models/option_test.rb
@@ -18,8 +18,4 @@ class OptionTest < ActiveSupport::TestCase
     @option.question_id = nil
     assert_not @option.valid?
   end
-
-  test 'has many answers' do
-    assert @option.answers.count > 1
-  end
 end

--- a/test/models/participant_test.rb
+++ b/test/models/participant_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class ParticipantTest < ActiveSupport::TestCase
   def setup
     @participant = participants(:one)
+    @campaign = campaigns(:malaria)
   end
 
   test 'should be valid' do
@@ -16,5 +17,37 @@ class ParticipantTest < ActiveSupport::TestCase
 
   test 'has many answers' do
     assert @participant.answers.count > 1
+  end
+
+  test 'track_campaign' do
+    @participant.track_campaign(@campaign.id, 1)
+    assert @participant.current_campaign == @campaign.id
+    assert @participant.question_count == 1
+  end
+
+  test 'tracked_campaign' do
+    @participant.track_campaign(@campaign.id, 1)
+    assert @participant.tracked_campaign == @campaign
+  end
+
+  test 'campaign_incomplete?' do
+    @participant.track_campaign(@campaign.id, 1)
+    assert @participant.campaign_incomplete? == true
+  end
+
+  test 'last_answer_entry' do
+    Answer.create(participant_id: @participant.id, campaign_id: @campaign.id,
+      question_text: "Can Malaria Affect Animals?", question_reply: "No")
+    assert @participant.last_answer_entry.question_text == "Can Malaria Affect Animals?"
+  end
+
+  test 'next_question' do
+    @participant.track_campaign(@campaign.id, 1)
+    assert @participant.next_question == Question.find_by(title: "do you know about proteins?")
+  end
+
+  test 'current_question' do
+    @participant.track_campaign(@campaign.id,1)
+    assert @participant.current_question == "what is your favourite food?"
   end
 end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -22,8 +22,4 @@ class QuestionTest < ActiveSupport::TestCase
   test 'has many options' do
     assert @question.options.count > 1
   end
-
-  test 'has many answers' do
-    assert @question.answers.count > 1
-  end
 end


### PR DESCRIPTION
#4 
As an Administrator
I Want To Send Participants Questions
  When They Have Finished Answering The Previous Questions
So That I can Collect all the Data needed for the campaign for the participants

##### Acceptance Criteria
- [x] GIVEN I Send Participants questions, THEN The Following Should be put into consideration
  - if the Participant Has Already received the first question, then they should not be resent the first question if they have not taken part in the campaign as yet
 - the participant should only get the next question if they answer the previous
 - When the participants has finished answering the questions, they should not be resent the questions